### PR TITLE
feat: Add ProjectileEnemy firing/attack logic and bullet damage

### DIFF
--- a/JumpTheGun/Assets/Prefabs/Bullet.prefab
+++ b/JumpTheGun/Assets/Prefabs/Bullet.prefab
@@ -149,5 +149,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 006f056b1089fe6438bf5ffe7ff92213, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 20
+  speed: 100
   lifetime: 5
+  damage: 15

--- a/JumpTheGun/Assets/Scripts/EnemyScripts/EnemyBase.cs
+++ b/JumpTheGun/Assets/Scripts/EnemyScripts/EnemyBase.cs
@@ -31,9 +31,9 @@ public abstract class EnemyBase : MonoBehaviour
     {
         // Automatically find the player by tag if not assigned in Inspector
         if (player == null) player = GameObject.FindWithTag("Player");
-        
+
         CachePlayerDamageable();
-        
+
         // Start patrolling if points are assigned
         if (HasPatrol()) agent.destination = destinations[currentDestination].position;
     }
@@ -74,7 +74,7 @@ public abstract class EnemyBase : MonoBehaviour
     {
         // If there's nowhere to patrol, stay in "Chase" mode (searching)
         if (!HasPatrol()) { isChasing = true; return; }
-        
+
         // Logic for entering and leaving the chase state (Hysteresis prevents flickering)
         if (!isChasing && dist <= chaseRange) isChasing = true;
         if (isChasing && dist > loseRange) isChasing = false;
@@ -104,7 +104,7 @@ public abstract class EnemyBase : MonoBehaviour
     {
         Vector3 dir = (player.transform.position - transform.position).normalized;
         dir.y = 0; // Keep the enemy upright (don't tilt up/down)
-        
+
         if (dir.sqrMagnitude > 0.01f)
         {
             // Slerp provides smooth rotation. Increase '10f' to make them turn faster.
@@ -123,9 +123,9 @@ public abstract class EnemyBase : MonoBehaviour
     protected virtual void PatrolStep()
     {
         if (!HasPatrol()) return;
-        
+
         agent.isStopped = false;
-        
+
         // Check if the enemy has reached the current patrol point
         if (agent.remainingDistance <= 0.5f)
         {
@@ -142,5 +142,27 @@ public abstract class EnemyBase : MonoBehaviour
     protected void CachePlayerDamageable()
     {
         if (player != null) playerDamageable = player.GetComponentInParent<IDamageable>();
+    }
+
+    /// <summary>
+    /// Dynamically calculates the actual center of the player's hitbox, there might be a cleaner way to do this lol
+    /// </summary>
+    protected Vector3 GetPlayerHitboxCenter()
+    {
+        if (player == null) return Vector3.zero;
+
+        // Try to find a CapsuleCollider on the player
+        CapsuleCollider capsule = player.GetComponent<CapsuleCollider>();
+        if (capsule == null) capsule = player.GetComponentInChildren<CapsuleCollider>();
+        if (capsule == null) capsule = player.GetComponentInParent<CapsuleCollider>();
+
+        // If found, calculate the actual center based on the collider's dimensions
+        if (capsule != null)
+        {
+            return player.transform.position + capsule.center;
+        }
+
+        // fallback, assumes height of 1 unit
+        return player.transform.position + Vector3.up * 0.5f;
     }
 }

--- a/JumpTheGun/Assets/Scripts/EnemyScripts/ProjectileEnemy.cs
+++ b/JumpTheGun/Assets/Scripts/EnemyScripts/ProjectileEnemy.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 /// <summary>
 /// A specialized enemy that inherits from EnemyBase to handle ranged projectile attacks.
 /// This class focuses on spawning a projectile (like a bullet) when the player is within attack range.
+/// </summary>
 public class ProjectileEnemy : EnemyBase
 {
     [Header("Projectile Settings")]
@@ -12,28 +13,70 @@ public class ProjectileEnemy : EnemyBase
     [Tooltip("The exact position and rotation where the bullet will spawn.")]
     [SerializeField] private Transform firePoint;
 
-    /// <summary>
-    /// Overrides the abstract Attack method from EnemyBase. 
-    /// This is called automatically by the base class when the player is within AttackRange.
-    /// 
-    protected override void Attack()
+    [Header("Line of Sight Detection")]
+    [Tooltip("Layers the line of sight cannot pass through (Walls, Ground, etc.).")]
+    [SerializeField] private LayerMask obstacleLayer;
+
+    [Tooltip("How directly the enemy must face the player to attempt firing (0 to 1).")]
+    [Range(0, 1)][SerializeField] private float dotThreshold = 0.5f;
+
+    protected override void Update()
     {
-        // Safety check to ensure we have a bullet to shoot and a place to shoot it from
-        if (projectilePrefab != null && firePoint != null)
+        if (player == null || !agent.isOnNavMesh) return;
+
+        float dist = Vector3.Distance(transform.position, player.transform.position);
+
+        if (dist <= attackRange)
         {
-            // Spawn the projectile at the FirePoint's position and rotation
-            // The 'Instantiate' function creates a clone of the prefab in the game world
-            GameObject projectile = Instantiate(projectilePrefab, firePoint.position, firePoint.rotation);
-            
-            // Deal damage to the player when the projectile hits them. This can be done by adding a script to the projectile prefab that handles collision and damage logic.
-            Debug.Log("Projectile Fired!");
+            agent.isStopped = true;
+            FacePlayer();
         }
         else
         {
-            Debug.LogWarning("ProjectileEnemy: Missing Projectile Prefab or Fire Point!");
+            agent.isStopped = false;
+            agent.SetDestination(player.transform.position);
+        }
+
+        CheckLineOfSightAndAttack();
+    }
+
+    private void CheckLineOfSightAndAttack()
+    {
+        if (player == null || firePoint == null) return;
+
+        Vector3 startPos = firePoint.position;
+        Vector3 playerCenter = GetPlayerHitboxCenter();
+        Vector3 dirToPlayer = (playerCenter - startPos).normalized;
+        float distToPlayer = Vector3.Distance(startPos, playerCenter);
+
+        float dot = Vector3.Dot(transform.forward, dirToPlayer);
+        if (dot <= dotThreshold) return;
+
+        bool blocked = Physics.Raycast(startPos, dirToPlayer, distToPlayer, obstacleLayer);
+        if (blocked) return;
+
+        if (Time.time >= nextAttackTime)
+        {
+            Attack();
+            nextAttackTime = Time.time + attackCooldown;
         }
     }
 
-    // Since you mentioned the enemy turns slowly, you can override Update 
-    // to call the base logic, or simply adjust the rotation speed in FacePlayer.
+    /// <summary>
+    /// Spawns a projectile aimed at the player's center
+    /// </summary>
+    protected override void Attack()
+    {
+        if (projectilePrefab == null || firePoint == null || player == null) return;
+
+        Vector3 dirToPlayer = (GetPlayerHitboxCenter() - firePoint.position).normalized;
+
+        GameObject projectile = Instantiate(projectilePrefab, firePoint.position, Quaternion.LookRotation(dirToPlayer));
+
+        if (projectile.TryGetComponent<Collider>(out var projectileCollider))
+        {
+            foreach (Collider enemyCollider in GetComponents<Collider>())
+                Physics.IgnoreCollision(projectileCollider, enemyCollider);
+        }
+    }
 }

--- a/JumpTheGun/Assets/Scripts/Weapon Logic/BulletLogic.cs
+++ b/JumpTheGun/Assets/Scripts/Weapon Logic/BulletLogic.cs
@@ -9,6 +9,10 @@ public class BulletLogic : MonoBehaviour
     [Tooltip("How many seconds the bullet exists before being automatically destroyed.")]
     public float lifetime = 2f;
 
+    [Header("Damage Settings")]
+    [Tooltip("Damage dealt on impact.")]
+    public int damage = 0;
+
     void Start()
     {
         // This schedules the GameObject for destruction as soon as it is spawned.
@@ -18,10 +22,19 @@ public class BulletLogic : MonoBehaviour
 
     void Update()
     {
-        // Move the bullet forward along its local Z-axis (blue arrow).
-        // We multiply by Time.deltaTime to ensure movement is consistent regardless of frame rate.
-        transform.Translate(Vector3.forward * speed * Time.deltaTime);
+        Vector3 moveDirection = transform.forward;
+        float moveDistance = speed * Time.deltaTime;
+        // mostly a safety to prevent tunneling, continuous collision detection attribute should prevent though
+        if (Physics.Raycast(transform.position, moveDirection, out RaycastHit hit, moveDistance))
+        {
+            transform.position = hit.point;
+        }
+        else
+        {
+            transform.position += moveDirection * moveDistance;
+        }
     }
+
 
     /// <summary>
     /// This runs when the bullet's trigger collider touches another collider.
@@ -32,21 +45,24 @@ public class BulletLogic : MonoBehaviour
     {
         // Log the name of the object hit to the Console for debugging.
         Debug.Log("Hit: " + other.name);
-        
+
         Parry parry = other.GetComponent<Parry>();
         if (parry != null)
         {
             transform.rotation = parry.direction;
             return;
         }
-        
-        // Here is where you would typically check if 'other' has a health script:
-        // if (other.CompareTag("Player")) { /* Apply Damage */ }
 
-
-        // Only remove the bullet if it hits an enemy.
-        // Removes cases of bullets disappearing when hitting themselves, or invisible trigger colliders.
-        if (other.CompareTag("Enemy"))
+        if (other.CompareTag("Player"))
+        {
+            if (other.TryGetComponent<IDamageable>(out var damageable))
+            {
+                damageable.TakeDamage(damage);
+                Debug.Log("Enemy projectile dealt " + damage + " damage to player!");
+            }
+            Destroy(gameObject);
+        }
+        else
         {
             Destroy(gameObject);
         }


### PR DESCRIPTION
Resolves #10 

- Projectile Enemy aims at center of player, relies on underlying logic of the project (e.g. BulletLogic).
- Noticed some problems with collision even with continuous detection? Added some logic to snap to the collider that would be hit, you can remove this if you disagree, it could be a different issue but it seemed to fix it (not experienced with game dev lol)